### PR TITLE
Update preview_dataset.py

### DIFF
--- a/scripts/preview_dataset.py
+++ b/scripts/preview_dataset.py
@@ -21,6 +21,7 @@ lmt_images = {
 
 
 def draw_spline(image, lane, ys, color=[0, 0, 255]):
+    lane = [lane for lane in lane if str(lane) != 'nan']
     pts = [[x, ys[i]]for i, x in enumerate(lane) if not math.isnan(x)]
     if len(pts)-1 > 0:
         spline = interpolate.splrep([pt[1] for pt in pts], [pt[0] for pt in pts], k=len(pts)-1)


### PR DESCRIPTION
My appreciation for your work sir , i just have a small problem
when one  of the Ground Truth spline points is nan like[ in the the data set id="BR_S02" frame id="119" the right lane P4 is nan ]
 the code gives this Error  "(TypeError: must be real number, not str)"
the condition "` if not math.isnan(x)`" in line 24
    `pts = [[x, ys[i]]for i, x in enumerate(lane) if not math.isnan(x)] `doesn't solve the problem.
i think it is better to take the nan elements out  before enumerate 
`lane = [lane for lane in lane if str(lane) != 'nan']`